### PR TITLE
Super simple change to change the returned element from a div to a span

### DIFF
--- a/__tests__/render.js
+++ b/__tests__/render.js
@@ -10,7 +10,7 @@ describe('SanitizedHTML', () => {
       ReactDOMServer.renderToStaticMarkup(
         <SanitizedHTML html={ '<a href="http://bing.com/">Bing</a>' }/>
       )
-    ).toBe('<div><a href="http://bing.com/">Bing</a></div>');
+    ).toBe('<span><a href="http://bing.com/">Bing</a></span>');
   });
 
   test('should render only allowed tags', () => {
@@ -21,6 +21,6 @@ describe('SanitizedHTML', () => {
           html={ '<a href="http://bing.com/"><strong>Bing</strong></a>' }
         />
       )
-    ).toBe('<div><a href="http://bing.com/">Bing</a></div>');
+    ).toBe('<span><a href="http://bing.com/">Bing</a></span>');
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ const SanitizedHTML = props => {
   );
 
   return (
-    <div
+    <span
       className={ props.className }
       dangerouslySetInnerHTML={{ __html: sanitizedHTML }}
       id={ props.id }


### PR DESCRIPTION
This fixes semantic issues that come up when using this to sanitize text inside of a link or paragraph, for instance.

I received warnings because you can’t have a `<div>` inside of a `<p>` tag.