### PR TITLE
Fix prop type warning for transformTags

### DIFF
--- a/__tests__/render.js
+++ b/__tests__/render.js
@@ -23,4 +23,33 @@ describe('SanitizedHTML', () => {
       )
     ).toBe('<div><a href="http://bing.com/">Bing</a></div>');
   });
+
+  test('should unconditionally transform tags', () => {
+    expect(
+      ReactDOMServer.renderToStaticMarkup(
+        <SanitizedHTML
+          transformTags={{i: 'em'}}
+          html={ '<i>Important</i>' }
+        />
+      )
+    ).toBe('<div><em>Important</em></div>');
+  });
+
+  test('should transform tags with custom filter', () => {
+    const setHref = (tagName, attribs) => {
+      attribs.href = 'http://example.com/';
+      return {
+        tagName: tagName,
+        attribs: attribs
+      };
+    };
+    expect(
+      ReactDOMServer.renderToStaticMarkup(
+        <SanitizedHTML
+          transformTags={{a: setHref}}
+          html={ '<a href="http://bing.com/">Bing</a>' }
+        />
+      )
+    ).toBe('<div><a href="http://example.com/">Bing</a></div>');
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ SanitizedHTML.propTypes = {
   nonTextTags          : PropTypes.arrayOf(PropTypes.string),
   parser               : PropTypes.any,
   selfClosing          : PropTypes.arrayOf(PropTypes.string),
-  transformTags        : PropTypes.objectOf(PropTypes.oneOf([PropTypes.func, PropTypes.string])),
+  transformTags        : PropTypes.objectOf(PropTypes.oneOfType([PropTypes.func, PropTypes.string])),
 
   className: PropTypes.string,
   id       : PropTypes.string,


### PR DESCRIPTION
`transformTags` filters are [declared](https://github.com/compulim/react-sanitized-html/blob/master/src/index.js#L62) as `oneOf` function or string. But `oneOf` is for [literal string enums](https://reactjs.org/docs/typechecking-with-proptypes.html): we need `oneOfType` instead.

This generates console warnings for all uses of `transformTags`, e.g.:

````
Warning: Failed prop type: Invalid prop `transformTags.i` of value `em` supplied to `SanitizedHTML`, expected one of [null,null].
        in SanitizedHTML
````