### PR TITLE
Fix allowed tags and attributes proptypes

### DIFF
--- a/__tests__/render.js
+++ b/__tests__/render.js
@@ -23,4 +23,42 @@ describe('SanitizedHTML', () => {
       )
     ).toBe('<div><a href="http://bing.com/">Bing</a></div>');
   });
+
+  test('should render all tags with no attributes', () => {
+    expect(
+      ReactDOMServer.renderToStaticMarkup(
+        <SanitizedHTML
+          allowedTags={false}
+          allowedAttributes={{}}
+          html={ '<a href="http://bing.com/"><strong>Bing</strong></a>' }
+        />
+      )
+    ).toBe('<div><a><strong>Bing</strong></a></div>');
+  });
+
+  test('should render only allowed tags with all attributes', () => {
+    expect(
+      ReactDOMServer.renderToStaticMarkup(
+        <SanitizedHTML
+          allowedTags={['strong']}
+          allowedAttributes={false}
+          html={ `<a href="http://bing.com/"><strong onclick="alert('Bing');">Bing</strong></a>` }
+        />
+      )
+    ).toBe(`<div><strong onclick="alert('Bing');">Bing</strong></div>`);
+  });
+
+  test('should render only allowed tags with allowed attributes', () => {
+    expect(
+      ReactDOMServer.renderToStaticMarkup(
+        <SanitizedHTML
+          allowedTags={['strong']}
+          allowedAttributes={{
+            'strong': ['title']
+          }}
+          html={ `<a href="http://bing.com/"><strong title="Bang" onclick="alert('Bing');" >Bing</strong></a>` }
+        />
+      )
+    ).toBe(`<div><strong title="Bang">Bing</strong></div>`);
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -49,11 +49,11 @@ SanitizedHTML.defaultProps = {
 
 SanitizedHTML.propTypes = {
   allowProtocolRelative: PropTypes.bool,
-  allowedAttributes    : PropTypes.objectOf(PropTypes.arrayOf(PropTypes.string)),
+  allowedAttributes    : PropTypes.oneOfType([PropTypes.objectOf(PropTypes.arrayOf(PropTypes.string)), PropTypes.oneOf([false])]),
   allowedClasses       : PropTypes.objectOf(PropTypes.arrayOf(PropTypes.string)),
   allowedSchemes       : PropTypes.arrayOf(PropTypes.string),
   allowedSchemesByTag  : PropTypes.objectOf(PropTypes.arrayOf(PropTypes.string)),
-  allowedTags          : PropTypes.arrayOf(PropTypes.string),
+  allowedTags          : PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.oneOf([false])]),
   exclusiveFilter      : PropTypes.func,
   html                 : PropTypes.string.isRequired,
   nonTextTags          : PropTypes.arrayOf(PropTypes.string),


### PR DESCRIPTION
Fix proptypes check for allowedTags and allowedAttributes.
sanitized-html allows also `false` value to be passed there.